### PR TITLE
Added CMakeLists.txt to build CLSmith and cl_launcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,281 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(CLSmith)
+
+include(CheckIncludeFile)
+
+set(CLSmith_PACKAGE "CLSmith")
+set(CLSmith_PACKAGE_BUGREPORT "mail@example.org")
+set(CLSmith_PACKAGE_NAME "CLSmith")
+set(CLSmith_PACKAGE_STRING "CLSmith x.y.z")
+set(CLSmith_PACKAGE_TARNAME "CLSmith")
+set(CLSmith_PACKAGE_URL "http://multicore.doc.ic.ac.uk/tools/CLsmith/index.php")
+set(CLSmith_PACKAGE_VERSION "x.y.z")
+set(CLSmith_VERSION "x.y.z")
+
+execute_process(COMMAND "git" "show" "-s" "--format=%h" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" OUTPUT_VARIABLE CLSmith_GIT_HASH)
+string(STRIP "${CLSmith_GIT_HASH}" CLSmith_GIT_HASH)
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "No build type selected, default to RelWithDebInfo")
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif()
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-long-long -std=c++11")
+SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
+SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3 -g")
+SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+
+add_definitions(-DGIT_VERSION=\"${CLSmith_GIT_HASH}\")
+add_definitions(-DTARGET_CPU_${CMAKE_SYSTEM_PROCESSOR}=1)
+
+add_definitions(-DPACKAGE_NAME=\"${CLSmith_PACKAGE_NAME}\")
+add_definitions(-DPACKAGE_TARNAME=\"${CLSmith_PACKAGE_TARNAME}\")
+add_definitions(-DPACKAGE_VERSION=\"${CLSmith_PACKAGE_VERSION}\")
+add_definitions(-DPACKAGE_STRING=\"${CLSmith_PACKAGE_STRING}\")
+add_definitions(-DPACKAGE_BUGREPORT=\"${CLSmith_PACKAGE_BUGREPORT}\")
+add_definitions(-DPACKAGE_URL=\"${CLSmith_PACKAGE_URL}\")
+add_definitions(-DPACKAGE=\"${CLSmith_PACKAGE}\")
+add_definitions(-DVERSION=\"${CLSmith_VERSION}\")
+
+check_include_file("dlfcn.h" HAVE_DLFCN_H)
+check_include_file("inttypes.h" HAVE_INTTYPES_H)
+check_include_file("memory.h" HAVE_MEMORY_H)
+check_include_file("stdint.h" HAVE_STDINT_H)
+check_include_file("stdlib.h" HAVE_STDLIB_H)
+check_include_file("strings.h" HAVE_STRINGS_H)
+check_include_file("string.h" HAVE_STRING_H)
+check_include_file("sys/stat.h" HAVE_SYS_STAT_H)
+check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
+check_include_file("unistd.h" HAVE_UNISTD_H)
+
+include_directories(src)
+
+add_executable(CLSmith
+    #CSmith files
+    src/AbsExtension.cpp
+    src/AbsExtension.h
+    src/AbsProgramGenerator.cpp
+    src/AbsProgramGenerator.h
+    src/AbsRndNumGenerator.cpp
+    src/AbsRndNumGenerator.h
+    src/ArrayVariable.cpp
+    src/ArrayVariable.h
+    src/Block.cpp
+    src/Block.h
+    src/Bookkeeper.cpp
+    src/Bookkeeper.h
+    src/CFGEdge.cpp
+    src/CFGEdge.h
+    src/CGContext.cpp
+    src/CGContext.h
+    src/CGOptions.cpp
+    src/CGOptions.h
+    src/CVQualifiers.cpp
+    src/CVQualifiers.h
+    src/Common.h
+    src/CommonMacros.h
+    src/CompatibleChecker.cpp
+    src/CompatibleChecker.h
+    src/Constant.cpp
+    src/Constant.h
+    src/CoverageTestExtension.cpp
+    src/CoverageTestExtension.h
+    src/CrestExtension.cpp
+    src/CrestExtension.h
+    src/DFSOutputMgr.cpp
+    src/DFSOutputMgr.h
+    src/DFSProgramGenerator.cpp
+    src/DFSProgramGenerator.h
+    src/DFSRndNumGenerator.cpp
+    src/DFSRndNumGenerator.h
+    src/DefaultOutputMgr.cpp
+    src/DefaultOutputMgr.h
+    src/DefaultProgramGenerator.cpp
+    src/DefaultProgramGenerator.h
+    src/DefaultRndNumGenerator.cpp
+    src/DefaultRndNumGenerator.h
+    src/DeltaMonitor.cpp
+    src/DeltaMonitor.h
+    src/DepthSpec.cpp
+    src/DepthSpec.h
+    src/Effect.cpp
+    src/Effect.h
+    src/Enumerator.h
+    src/Error.cpp
+    src/Error.h
+    src/Expression.cpp
+    src/Expression.h
+    src/ExpressionAssign.cpp
+    src/ExpressionAssign.h
+    src/ExpressionComma.cpp
+    src/ExpressionComma.h
+    src/ExpressionFuncall.cpp
+    src/ExpressionFuncall.h
+    src/ExpressionVariable.cpp
+    src/ExpressionVariable.h
+    src/ExtensionMgr.cpp
+    src/ExtensionMgr.h
+    src/ExtensionValue.cpp
+    src/ExtensionValue.h
+    src/Fact.cpp
+    src/Fact.h
+    src/FactMgr.cpp
+    src/FactMgr.h
+    src/FactPointTo.cpp
+    src/FactPointTo.h
+    src/FactUnion.cpp
+    src/FactUnion.h
+    src/Filter.cpp
+    src/Filter.h
+    src/Finalization.cpp
+    src/Finalization.h
+    src/Function.cpp
+    src/Function.h
+    src/FunctionInvocation.cpp
+    src/FunctionInvocation.h
+    src/FunctionInvocationBinary.cpp
+    src/FunctionInvocationBinary.h
+    src/FunctionInvocationUnary.cpp
+    src/FunctionInvocationUnary.h
+    src/FunctionInvocationUser.cpp
+    src/FunctionInvocationUser.h
+    src/KleeExtension.cpp
+    src/KleeExtension.h
+    src/Lhs.cpp
+    src/Lhs.h
+    src/LinearSequence.cpp
+    src/LinearSequence.h
+    src/MspFilters.cpp
+    src/MspFilters.h
+    src/OutputMgr.cpp
+    src/OutputMgr.h
+    src/PartialExpander.cpp
+    src/PartialExpander.h
+    src/Probabilities.cpp
+    src/Probabilities.h
+    src/ProbabilityTable.h
+    src/RandomNumber.cpp
+    src/RandomNumber.h
+    #src/RandomProgramGenerator.cpp
+    src/Reducer.cpp
+    src/Reducer.h
+    src/ReducerOutputMgr.cpp
+    src/ReducerOutputMgr.h
+    src/SafeOpFlags.cpp
+    src/SafeOpFlags.h
+    src/Sequence.cpp
+    src/Sequence.h
+    src/SequenceFactory.cpp
+    src/SequenceFactory.h
+    src/SequenceLineParser.h
+    src/SimpleDeltaRndNumGenerator.cpp
+    src/SimpleDeltaRndNumGenerator.h
+    src/SimpleDeltaSequence.cpp
+    src/SimpleDeltaSequence.h
+    src/SplatExtension.cpp
+    src/SplatExtension.h
+    src/Statement.cpp
+    src/Statement.h
+    src/StatementArrayOp.cpp
+    src/StatementArrayOp.h
+    src/StatementAssign.cpp
+    src/StatementAssign.h
+    src/StatementBreak.cpp
+    src/StatementBreak.h
+    src/StatementContinue.cpp
+    src/StatementContinue.h
+    src/StatementExpr.cpp
+    src/StatementExpr.h
+    src/StatementFor.cpp
+    src/StatementFor.h
+    src/StatementGoto.cpp
+    src/StatementGoto.h
+    src/StatementIf.cpp
+    src/StatementIf.h
+    src/StatementReturn.cpp
+    src/StatementReturn.h
+    src/StringUtils.cpp
+    src/StringUtils.h
+    src/Type.cpp
+    src/Type.h
+    src/Variable.cpp
+    src/Variable.h
+    src/VariableSelector.cpp
+    src/VariableSelector.h
+    src/VectorFilter.cpp
+    src/VectorFilter.h
+    src/platform.cpp
+    src/platform.h
+    src/random.cpp
+    src/random.h
+    src/util.cpp
+    src/util.h
+    #CLSmith files
+    src/CLSmith/CLOutputMgr.cpp
+    src/CLSmith/CLOutputMgr.h
+    src/CLSmith/CLProgramGenerator.cpp
+    src/CLSmith/CLProgramGenerator.h
+    src/CLSmith/Globals.cpp
+    src/CLSmith/Globals.h
+    src/CLSmith/CLRandomProgramGenerator.cpp
+    src/CLSmith/Walker.cpp
+    src/CLSmith/Walker.h
+    src/CLSmith/Divergence.cpp
+    src/CLSmith/Divergence.h
+    src/CLSmith/CLExpression.cpp
+    src/CLSmith/CLExpression.h
+    src/CLSmith/CLStatement.cpp
+    src/CLSmith/CLStatement.h
+    src/CLSmith/CLVariable.cpp
+    src/CLSmith/CLVariable.h
+    src/CLSmith/StatementBarrier.cpp
+    src/CLSmith/StatementBarrier.h
+    src/CLSmith/MemoryBuffer.cpp
+    src/CLSmith/MemoryBuffer.h
+    src/CLSmith/Vector.cpp
+    src/CLSmith/Vector.h
+    src/CLSmith/CLOptions.cpp
+    src/CLSmith/CLOptions.h
+    src/CLSmith/ExpressionVector.cpp
+    src/CLSmith/ExpressionVector.h
+    src/CLSmith/ExpressionAtomic.cpp
+    src/CLSmith/ExpressionAtomic.h
+    src/CLSmith/StatementEMI.cpp
+    src/CLSmith/StatementEMI.h
+    src/CLSmith/StatementAtomicResult.cpp
+    src/CLSmith/StatementAtomicResult.h
+    src/CLSmith/FunctionInvocationBuiltIn.cpp
+    src/CLSmith/FunctionInvocationBuiltIn.h
+    src/CLSmith/ExpressionID.cpp
+    src/CLSmith/ExpressionID.h
+    src/CLSmith/StatementComm.cpp
+    src/CLSmith/StatementComm.h
+    src/CLSmith/StatementAtomicReduction.cpp
+    src/CLSmith/StatementAtomicReduction.h
+    src/CLSmith/StatementMessage.cpp
+    src/CLSmith/StatementMessage.h
+)
+
+install(TARGETS CLSmith
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
+
+find_package(OpenCL)
+
+if(OpenCL_FOUND)
+    include_directories(${OpenCL_INCLUDE_DIRS})
+    add_executable(cl_launcher
+        src/CLSmith/cl_launcher.c
+    )
+
+    target_link_libraries(cl_launcher ${OpenCL_LIBRARIES})
+
+    install(TARGETS cl_launcher
+            RUNTIME DESTINATION bin
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+    )
+else()
+    message(WARNING "Cannot build cl_launcher because OpenCL was not found")
+endif()

--- a/README
+++ b/README
@@ -13,3 +13,12 @@ csmith as intact as possible (with some modifications made to allow CLSmith to
 inject functionctionality into csmith or to pass control to CLSmith). Keeping
 csmith and CLSmith separate turned out to be very tricky and probably not worth
 the effort.
+
+Both CLSmith and cl_launcher can be built with the included CMake files:
+
+$ mkdir build
+$ cd build
+$ cmake ..
+$ cmake --build . --config Release -- -j 8
+
+This generates the CLSmith and cl_launcher executables inside the build directory.

--- a/src/CLSmith/cl_launcher.c
+++ b/src/CLSmith/cl_launcher.c
@@ -2,7 +2,12 @@
 // Usage: cl_launcher <cl_program> <platform_id> <device_id> [flags...]
 
 #define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+
+#ifdef __APPLE__
+#include <OpenCL/opencl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 #include <assert.h>
 #include <inttypes.h>


### PR DESCRIPTION
The CMake configuration allows to build CLSmith and cl_launcher platform independent (in theory, see below) and without the need of running make twice.
I have successfully tested it on Mac and Linux and it _should_ also work on Windows. Though it might be the case that some of the required headers are missing. I will test it later.

There are some fields at the top of the CMakeLists.txt file like bug report email address and version that you might want to fill in when merging the pull request.
