### PR TITLE
Build CLSmith on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,281 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(CLSmith)
+
+include(CheckIncludeFile)
+
+set(CLSmith_PACKAGE "CLSmith")
+set(CLSmith_PACKAGE_BUGREPORT "mail@example.org")
+set(CLSmith_PACKAGE_NAME "CLSmith")
+set(CLSmith_PACKAGE_STRING "CLSmith x.y.z")
+set(CLSmith_PACKAGE_TARNAME "CLSmith")
+set(CLSmith_PACKAGE_URL "http://multicore.doc.ic.ac.uk/tools/CLsmith/index.php")
+set(CLSmith_PACKAGE_VERSION "x.y.z")
+set(CLSmith_VERSION "x.y.z")
+
+execute_process(COMMAND "git" "show" "-s" "--format=%h" WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}" OUTPUT_VARIABLE CLSmith_GIT_HASH)
+string(STRIP "${CLSmith_GIT_HASH}" CLSmith_GIT_HASH)
+
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "No build type selected, default to RelWithDebInfo")
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+endif()
+
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-long-long -std=c++11")
+SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
+SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3 -g")
+SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
+
+add_definitions(-DGIT_VERSION=\"${CLSmith_GIT_HASH}\")
+add_definitions(-DTARGET_CPU_${CMAKE_SYSTEM_PROCESSOR}=1)
+
+add_definitions(-DPACKAGE_NAME=\"${CLSmith_PACKAGE_NAME}\")
+add_definitions(-DPACKAGE_TARNAME=\"${CLSmith_PACKAGE_TARNAME}\")
+add_definitions(-DPACKAGE_VERSION=\"${CLSmith_PACKAGE_VERSION}\")
+add_definitions(-DPACKAGE_STRING=\"${CLSmith_PACKAGE_STRING}\")
+add_definitions(-DPACKAGE_BUGREPORT=\"${CLSmith_PACKAGE_BUGREPORT}\")
+add_definitions(-DPACKAGE_URL=\"${CLSmith_PACKAGE_URL}\")
+add_definitions(-DPACKAGE=\"${CLSmith_PACKAGE}\")
+add_definitions(-DVERSION=\"${CLSmith_VERSION}\")
+
+check_include_file("dlfcn.h" HAVE_DLFCN_H)
+check_include_file("inttypes.h" HAVE_INTTYPES_H)
+check_include_file("memory.h" HAVE_MEMORY_H)
+check_include_file("stdint.h" HAVE_STDINT_H)
+check_include_file("stdlib.h" HAVE_STDLIB_H)
+check_include_file("strings.h" HAVE_STRINGS_H)
+check_include_file("string.h" HAVE_STRING_H)
+check_include_file("sys/stat.h" HAVE_SYS_STAT_H)
+check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
+check_include_file("unistd.h" HAVE_UNISTD_H)
+
+include_directories(src)
+
+add_executable(CLSmith
+    #CSmith files
+    src/AbsExtension.cpp
+    src/AbsExtension.h
+    src/AbsProgramGenerator.cpp
+    src/AbsProgramGenerator.h
+    src/AbsRndNumGenerator.cpp
+    src/AbsRndNumGenerator.h
+    src/ArrayVariable.cpp
+    src/ArrayVariable.h
+    src/Block.cpp
+    src/Block.h
+    src/Bookkeeper.cpp
+    src/Bookkeeper.h
+    src/CFGEdge.cpp
+    src/CFGEdge.h
+    src/CGContext.cpp
+    src/CGContext.h
+    src/CGOptions.cpp
+    src/CGOptions.h
+    src/CVQualifiers.cpp
+    src/CVQualifiers.h
+    src/Common.h
+    src/CommonMacros.h
+    src/CompatibleChecker.cpp
+    src/CompatibleChecker.h
+    src/Constant.cpp
+    src/Constant.h
+    src/CoverageTestExtension.cpp
+    src/CoverageTestExtension.h
+    src/CrestExtension.cpp
+    src/CrestExtension.h
+    src/DFSOutputMgr.cpp
+    src/DFSOutputMgr.h
+    src/DFSProgramGenerator.cpp
+    src/DFSProgramGenerator.h
+    src/DFSRndNumGenerator.cpp
+    src/DFSRndNumGenerator.h
+    src/DefaultOutputMgr.cpp
+    src/DefaultOutputMgr.h
+    src/DefaultProgramGenerator.cpp
+    src/DefaultProgramGenerator.h
+    src/DefaultRndNumGenerator.cpp
+    src/DefaultRndNumGenerator.h
+    src/DeltaMonitor.cpp
+    src/DeltaMonitor.h
+    src/DepthSpec.cpp
+    src/DepthSpec.h
+    src/Effect.cpp
+    src/Effect.h
+    src/Enumerator.h
+    src/Error.cpp
+    src/Error.h
+    src/Expression.cpp
+    src/Expression.h
+    src/ExpressionAssign.cpp
+    src/ExpressionAssign.h
+    src/ExpressionComma.cpp
+    src/ExpressionComma.h
+    src/ExpressionFuncall.cpp
+    src/ExpressionFuncall.h
+    src/ExpressionVariable.cpp
+    src/ExpressionVariable.h
+    src/ExtensionMgr.cpp
+    src/ExtensionMgr.h
+    src/ExtensionValue.cpp
+    src/ExtensionValue.h
+    src/Fact.cpp
+    src/Fact.h
+    src/FactMgr.cpp
+    src/FactMgr.h
+    src/FactPointTo.cpp
+    src/FactPointTo.h
+    src/FactUnion.cpp
+    src/FactUnion.h
+    src/Filter.cpp
+    src/Filter.h
+    src/Finalization.cpp
+    src/Finalization.h
+    src/Function.cpp
+    src/Function.h
+    src/FunctionInvocation.cpp
+    src/FunctionInvocation.h
+    src/FunctionInvocationBinary.cpp
+    src/FunctionInvocationBinary.h
+    src/FunctionInvocationUnary.cpp
+    src/FunctionInvocationUnary.h
+    src/FunctionInvocationUser.cpp
+    src/FunctionInvocationUser.h
+    src/KleeExtension.cpp
+    src/KleeExtension.h
+    src/Lhs.cpp
+    src/Lhs.h
+    src/LinearSequence.cpp
+    src/LinearSequence.h
+    src/MspFilters.cpp
+    src/MspFilters.h
+    src/OutputMgr.cpp
+    src/OutputMgr.h
+    src/PartialExpander.cpp
+    src/PartialExpander.h
+    src/Probabilities.cpp
+    src/Probabilities.h
+    src/ProbabilityTable.h
+    src/RandomNumber.cpp
+    src/RandomNumber.h
+    #src/RandomProgramGenerator.cpp
+    src/Reducer.cpp
+    src/Reducer.h
+    src/ReducerOutputMgr.cpp
+    src/ReducerOutputMgr.h
+    src/SafeOpFlags.cpp
+    src/SafeOpFlags.h
+    src/Sequence.cpp
+    src/Sequence.h
+    src/SequenceFactory.cpp
+    src/SequenceFactory.h
+    src/SequenceLineParser.h
+    src/SimpleDeltaRndNumGenerator.cpp
+    src/SimpleDeltaRndNumGenerator.h
+    src/SimpleDeltaSequence.cpp
+    src/SimpleDeltaSequence.h
+    src/SplatExtension.cpp
+    src/SplatExtension.h
+    src/Statement.cpp
+    src/Statement.h
+    src/StatementArrayOp.cpp
+    src/StatementArrayOp.h
+    src/StatementAssign.cpp
+    src/StatementAssign.h
+    src/StatementBreak.cpp
+    src/StatementBreak.h
+    src/StatementContinue.cpp
+    src/StatementContinue.h
+    src/StatementExpr.cpp
+    src/StatementExpr.h
+    src/StatementFor.cpp
+    src/StatementFor.h
+    src/StatementGoto.cpp
+    src/StatementGoto.h
+    src/StatementIf.cpp
+    src/StatementIf.h
+    src/StatementReturn.cpp
+    src/StatementReturn.h
+    src/StringUtils.cpp
+    src/StringUtils.h
+    src/Type.cpp
+    src/Type.h
+    src/Variable.cpp
+    src/Variable.h
+    src/VariableSelector.cpp
+    src/VariableSelector.h
+    src/VectorFilter.cpp
+    src/VectorFilter.h
+    src/platform.cpp
+    src/platform.h
+    src/random.cpp
+    src/random.h
+    src/util.cpp
+    src/util.h
+    #CLSmith files
+    src/CLSmith/CLOutputMgr.cpp
+    src/CLSmith/CLOutputMgr.h
+    src/CLSmith/CLProgramGenerator.cpp
+    src/CLSmith/CLProgramGenerator.h
+    src/CLSmith/Globals.cpp
+    src/CLSmith/Globals.h
+    src/CLSmith/CLRandomProgramGenerator.cpp
+    src/CLSmith/Walker.cpp
+    src/CLSmith/Walker.h
+    src/CLSmith/Divergence.cpp
+    src/CLSmith/Divergence.h
+    src/CLSmith/CLExpression.cpp
+    src/CLSmith/CLExpression.h
+    src/CLSmith/CLStatement.cpp
+    src/CLSmith/CLStatement.h
+    src/CLSmith/CLVariable.cpp
+    src/CLSmith/CLVariable.h
+    src/CLSmith/StatementBarrier.cpp
+    src/CLSmith/StatementBarrier.h
+    src/CLSmith/MemoryBuffer.cpp
+    src/CLSmith/MemoryBuffer.h
+    src/CLSmith/Vector.cpp
+    src/CLSmith/Vector.h
+    src/CLSmith/CLOptions.cpp
+    src/CLSmith/CLOptions.h
+    src/CLSmith/ExpressionVector.cpp
+    src/CLSmith/ExpressionVector.h
+    src/CLSmith/ExpressionAtomic.cpp
+    src/CLSmith/ExpressionAtomic.h
+    src/CLSmith/StatementEMI.cpp
+    src/CLSmith/StatementEMI.h
+    src/CLSmith/StatementAtomicResult.cpp
+    src/CLSmith/StatementAtomicResult.h
+    src/CLSmith/FunctionInvocationBuiltIn.cpp
+    src/CLSmith/FunctionInvocationBuiltIn.h
+    src/CLSmith/ExpressionID.cpp
+    src/CLSmith/ExpressionID.h
+    src/CLSmith/StatementComm.cpp
+    src/CLSmith/StatementComm.h
+    src/CLSmith/StatementAtomicReduction.cpp
+    src/CLSmith/StatementAtomicReduction.h
+    src/CLSmith/StatementMessage.cpp
+    src/CLSmith/StatementMessage.h
+)
+
+install(TARGETS CLSmith
+        RUNTIME DESTINATION bin
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+)
+
+find_package(OpenCL)
+
+if(OpenCL_FOUND)
+    include_directories(${OpenCL_INCLUDE_DIRS})
+    add_executable(cl_launcher
+        src/CLSmith/cl_launcher.c
+    )
+
+    target_link_libraries(cl_launcher ${OpenCL_LIBRARIES})
+
+    install(TARGETS cl_launcher
+            RUNTIME DESTINATION bin
+            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+    )
+else()
+    message(WARNING "Cannot build cl_launcher because OpenCL was not found")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,10 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")
 endif()
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-long-long -std=c++11")
+if((CMAKE_CXX_COMPILER_ID MATCHES "Clang") OR (CMAKE_CXX_COMPILER_ID MATCHES "GNU"))
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wno-long-long -Wall -std=c++11")
+endif()
+
 SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g")
 SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O3 -g")
 SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3")
@@ -49,10 +52,20 @@ check_include_file("sys/stat.h" HAVE_SYS_STAT_H)
 check_include_file("sys/types.h" HAVE_SYS_TYPES_H)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 
+if(WIN32)
+    set(CLSmith_WINDOWS_SOURCES
+        runtime/windows/rand48.h
+        runtime/windows/_rand48.c
+        runtime/windows/lrand48.c
+        runtime/windows/srand48.c
+    )
+endif()
+
 include_directories(src)
 
 add_executable(CLSmith
     #CSmith files
+    ${CLSmith_WINDOWS_SOURCES}
     src/AbsExtension.cpp
     src/AbsExtension.h
     src/AbsProgramGenerator.cpp

--- a/README
+++ b/README
@@ -13,3 +13,12 @@ csmith as intact as possible (with some modifications made to allow CLSmith to
 inject functionctionality into csmith or to pass control to CLSmith). Keeping
 csmith and CLSmith separate turned out to be very tricky and probably not worth
 the effort.
+
+Both CLSmith and cl_launcher can be built with the included CMake files:
+
+$ mkdir build
+$ cd build
+$ cmake ..
+$ cmake --build . --config Release -- -j 8
+
+This generates the CLSmith and cl_launcher executables inside the build directory.

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -63,15 +63,6 @@
 
 #include "CLSmith/ExpressionAtomic.h"
 
-#if 0
-namespace CLSmith {
-namespace ExpressionAtomic {
-void RemoveBlockVars(Block* b);
-void GenBlockVars(Block* curr);
-}
-}
-#endif
-
 using namespace std;
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/Block.cpp
+++ b/src/Block.cpp
@@ -61,12 +61,16 @@
 #include "Expression.h"
 #include "VectorFilter.h"
 
+#include "CLSmith/ExpressionAtomic.h"
+
+#if 0
 namespace CLSmith {
 namespace ExpressionAtomic {
 void RemoveBlockVars(Block* b);
 void GenBlockVars(Block* curr);
 }
 }
+#endif
 
 using namespace std;
 

--- a/src/CLSmith/StatementComm.cpp
+++ b/src/CLSmith/StatementComm.cpp
@@ -85,7 +85,7 @@ void StatementComm::InitBuffers() {
   }
   permutations = MemoryBuffer::CreateMemoryBuffer(MemoryBuffer::kConst,
       "permutations", &Type::get_simple_type(eUInt), NULL,
-      {kPermCount, perm_size});
+      {static_cast<unsigned>(kPermCount), perm_size});
   local_values = MemoryBuffer::CreateMemoryBuffer(MemoryBuffer::kLocal,
       "l_comm_values", &Type::get_simple_type(eLongLong), Constant::make_int(1),
       {CLProgramGenerator::get_threads_per_group()});

--- a/src/CLSmith/cl_launcher.c
+++ b/src/CLSmith/cl_launcher.c
@@ -2,7 +2,12 @@
 // Usage: cl_launcher <cl_program> <platform_id> <device_id> [flags...]
 
 #define CL_USE_DEPRECATED_OPENCL_2_0_APIS
+
+#ifdef __APPLE__
+#include <OpenCL/opencl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 #include <assert.h>
 #include <inttypes.h>

--- a/src/FunctionInvocation.cpp
+++ b/src/FunctionInvocation.cpp
@@ -66,11 +66,15 @@
 #include "Constant.h"
 #include "CGOptions.h"
 
+#include "CLSmith/ExpressionVector.h"
+
+#if 0
 namespace CLSmith {
 namespace ExpressionVector {
 Expression *make_constant(const Type *type, int value);
 }  // namespace ExpressionVector
 }  // namespace CLSmith
+#endif
 
 using namespace std; 
 
@@ -261,8 +265,8 @@ FunctionInvocation::make_random_binary(CGContext &cg_context, const Type* type)
 			// avoid shifting negative or too much
 			if (!not_constant) {
 				rhs = lhs_type->eType == eVector ?
-					CLSmith::ExpressionVector::make_constant(rhs_type, lhs_type->SizeInBytes() * 8) :
-					Constant::make_random_upto(lhs_type->SizeInBytes() * 8);
+					dynamic_cast<Expression*>(CLSmith::ExpressionVector::make_constant(rhs_type, lhs_type->SizeInBytes() * 8)) :
+					dynamic_cast<Expression*>(Constant::make_random_upto(lhs_type->SizeInBytes() * 8));
 			} else {
 				rhs = Expression::make_random(rhs_cg_context, rhs_type, NULL, false, true, tt);
 			}

--- a/src/FunctionInvocation.cpp
+++ b/src/FunctionInvocation.cpp
@@ -68,14 +68,6 @@
 
 #include "CLSmith/ExpressionVector.h"
 
-#if 0
-namespace CLSmith {
-namespace ExpressionVector {
-Expression *make_constant(const Type *type, int value);
-}  // namespace ExpressionVector
-}  // namespace CLSmith
-#endif
-
 using namespace std; 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/FunctionInvocationBinary.cpp
+++ b/src/FunctionInvocationBinary.cpp
@@ -41,12 +41,16 @@
 #include "Block.h"
 #include "random.h"
 
+#include "CLSmith\Vector.h"
+
+#if 0
 // Required for get_type() to promote simple types.
 namespace CLSmith {
 namespace Vector {
 const Type *PromoteTypeToVectorType(const Type *type, int size);
 }  // namespace Vector
 }  // namespace CLSmith
+#endif
 
 using namespace std;
 

--- a/src/FunctionInvocationBinary.cpp
+++ b/src/FunctionInvocationBinary.cpp
@@ -41,16 +41,7 @@
 #include "Block.h"
 #include "random.h"
 
-#include "CLSmith\Vector.h"
-
-#if 0
-// Required for get_type() to promote simple types.
-namespace CLSmith {
-namespace Vector {
-const Type *PromoteTypeToVectorType(const Type *type, int size);
-}  // namespace Vector
-}  // namespace CLSmith
-#endif
+#include "CLSmith/Vector.h"
 
 using namespace std;
 

--- a/src/FunctionInvocationUnary.cpp
+++ b/src/FunctionInvocationUnary.cpp
@@ -39,16 +39,7 @@
 #include "CGContext.h"
 #include "random.h"
 
-#include "CLSmith\Vector.h"
-
-#if 0
-// Required for get_type() to promote simple types.
-namespace CLSmith {
-namespace Vector {
-const Type *PromoteTypeToVectorType(const Type *type, int size);
-}  // namespace Vector
-}  // namespace CLSmith
-#endif
+#include "CLSmith/Vector.h"
 
 using namespace std;
 

--- a/src/FunctionInvocationUnary.cpp
+++ b/src/FunctionInvocationUnary.cpp
@@ -39,12 +39,16 @@
 #include "CGContext.h"
 #include "random.h"
 
+#include "CLSmith\Vector.h"
+
+#if 0
 // Required for get_type() to promote simple types.
 namespace CLSmith {
 namespace Vector {
 const Type *PromoteTypeToVectorType(const Type *type, int size);
 }  // namespace Vector
 }  // namespace CLSmith
+#endif
 
 using namespace std;
 

--- a/src/Lhs.cpp
+++ b/src/Lhs.cpp
@@ -50,11 +50,15 @@
 #include <vector>
 #include "Block.h"
 
+#include "CLSmith\ExpressionAtomic.h"
+
+#if 0
 namespace CLSmith {
 namespace ExpressionAtomic {
 std::vector<Variable *>* GetBlockVars(Block* b);
 }
 }
+#endif
 
 using namespace std;
 

--- a/src/Lhs.cpp
+++ b/src/Lhs.cpp
@@ -50,15 +50,7 @@
 #include <vector>
 #include "Block.h"
 
-#include "CLSmith\ExpressionAtomic.h"
-
-#if 0
-namespace CLSmith {
-namespace ExpressionAtomic {
-std::vector<Variable *>* GetBlockVars(Block* b);
-}
-}
-#endif
+#include "CLSmith/ExpressionAtomic.h"
 
 using namespace std;
 

--- a/src/StatementIf.cpp
+++ b/src/StatementIf.cpp
@@ -45,6 +45,11 @@
 #include "DepthSpec.h"
 #include "util.h"
 
+#include "CLSmith\ExpressionAtomic.h"
+#include "CLSmith\StatementAtomicResult.h"
+#include "CLSmith\CLOptions.h"
+
+#if 0
 namespace CLSmith {
 namespace ExpressionAtomic {
 Expression* make_condition(CGContext& cg_context, const Type* type);
@@ -60,6 +65,7 @@ namespace CLOptions {
 bool atomics();
 }  // namespace CLOptions
 }  // namespace CLSmith
+#endif
 
 using namespace std;
 

--- a/src/StatementIf.cpp
+++ b/src/StatementIf.cpp
@@ -45,27 +45,9 @@
 #include "DepthSpec.h"
 #include "util.h"
 
-#include "CLSmith\ExpressionAtomic.h"
-#include "CLSmith\StatementAtomicResult.h"
-#include "CLSmith\CLOptions.h"
-
-#if 0
-namespace CLSmith {
-namespace ExpressionAtomic {
-Expression* make_condition(CGContext& cg_context, const Type* type);
-void DelBlockVars();
-}  // namespace ExpressionAtomic
-
-namespace StatementAtomicResult {
-void RecordIfID(int id, Expression* expr);
-}  // namespace StatementAtomicResult
-
-namespace CLOptions {
-// Checks whether the "--atomics" argument was given
-bool atomics();
-}  // namespace CLOptions
-}  // namespace CLSmith
-#endif
+#include "CLSmith/ExpressionAtomic.h"
+#include "CLSmith/StatementAtomicResult.h"
+#include "CLSmith/CLOptions.h"
 
 using namespace std;
 

--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -51,15 +51,7 @@
 #include "DepthSpec.h"
 #include "Enumerator.h"
 
-#include "CLSmith\Vector.h"
-
-#if 0
-namespace CLSmith {
-namespace Vector {
-void OutputVectorType(std::ostream& out, const Type *type, int vector_size);
-}  // namespace Vector
-}  // namespace CLSmith
-#endif
+#include "CLSmith/Vector.h"
 
 using namespace std;
 

--- a/src/Type.cpp
+++ b/src/Type.cpp
@@ -51,11 +51,15 @@
 #include "DepthSpec.h"
 #include "Enumerator.h"
 
+#include "CLSmith\Vector.h"
+
+#if 0
 namespace CLSmith {
 namespace Vector {
 void OutputVectorType(std::ostream& out, const Type *type, int vector_size);
 }  // namespace Vector
 }  // namespace CLSmith
+#endif
 
 using namespace std;
 

--- a/src/VariableSelector.cpp
+++ b/src/VariableSelector.cpp
@@ -62,20 +62,27 @@
 #include "ProbabilityTable.h"
 #include "StringUtils.h"
 
+#include "CLSmith/Vector.h"
+#include "CLSmith/CLOptions.h"
+
 // TODO Add ability to disable CLSmith, and prevent link failing on this function.
 // Maybe move to ArrayVariable, and call from CreateArrayVariable. Although this
 // would force us to always use vectors where we may not want them.
 namespace CLSmith {
+#if 0
 namespace Vector {
 ArrayVariable *CreateVectorVariable(const CGContext& cg_context, Block *blk,
     const std::string& name, const Type *type, const Expression *init,
     const CVQualifiers *qfer, const Variable *isFieldVarOf);  // Hook
 const Type& DemoteVectorTypeToType(const Type *type);  // Hook
 }  // namespace Vector
+#endif
 ArrayVariable *itemize_simd_hook(const ArrayVariable *av, int access_count);  // Hook
+#if 0
 namespace CLOptions {
 bool vectors(); // Hook
 }  // namespace CLOptions
+#endif
 }  // namespace CLSmith
 
 using namespace std;

--- a/src/VariableSelector.cpp
+++ b/src/VariableSelector.cpp
@@ -69,20 +69,7 @@
 // Maybe move to ArrayVariable, and call from CreateArrayVariable. Although this
 // would force us to always use vectors where we may not want them.
 namespace CLSmith {
-#if 0
-namespace Vector {
-ArrayVariable *CreateVectorVariable(const CGContext& cg_context, Block *blk,
-    const std::string& name, const Type *type, const Expression *init,
-    const CVQualifiers *qfer, const Variable *isFieldVarOf);  // Hook
-const Type& DemoteVectorTypeToType(const Type *type);  // Hook
-}  // namespace Vector
-#endif
 ArrayVariable *itemize_simd_hook(const ArrayVariable *av, int access_count);  // Hook
-#if 0
-namespace CLOptions {
-bool vectors(); // Hook
-}  // namespace CLOptions
-#endif
 }  // namespace CLSmith
 
 using namespace std;


### PR DESCRIPTION
In addition to the new CMake configuration I had to replace the forward declarations ("hooks" within Csmith code) with actual includes. MSBuild did not like the mixture of namespaces and classes and it seemed fairly hacky anyway.

If you're happy with the changes to CLSmith you can just use this pull request and ignore #2. This pull request includes all changes from #2 as well.
If you don't want to change CLSmith than just use #2 to get the CMake configuration which works for Linux and Mac
