### PR TITLE
Added the options to enable/disable loops and arrays

### DIFF
--- a/src/CGOptions.cpp
+++ b/src/CGOptions.cpp
@@ -137,6 +137,7 @@ DEFINE_GETTER_SETTER_BOOL(int8)
 DEFINE_GETTER_SETTER_BOOL(uint8)
 DEFINE_GETTER_SETTER_BOOL(pointers)
 DEFINE_GETTER_SETTER_BOOL(arrays)
+DEFINE_GETTER_SETTER_BOOL(loops)
 DEFINE_GETTER_SETTER_BOOL(strict_const_arrays)
 DEFINE_GETTER_SETTER_BOOL(jumps)
 DEFINE_GETTER_SETTER_BOOL(return_structs)
@@ -256,6 +257,7 @@ CGOptions::set_default_settings(void)
 	uint8(true);
 	pointers(true);
 	arrays(true);
+	loops(true);
 	strict_const_arrays(false);
 	jumps(true);
 	return_structs(true);

--- a/src/CGOptions.h
+++ b/src/CGOptions.h
@@ -259,6 +259,9 @@ public:
 	static bool arrays(void);
 	static bool arrays(bool p);
 
+	static bool loops(void);
+	static bool loops(bool p);
+
 	static bool strict_const_arrays(void);
 	static bool strict_const_arrays(bool p);
 
@@ -543,6 +546,7 @@ private:
 	static bool	uint8_;
 	static bool	pointers_;
 	static bool	arrays_;
+	static bool loops_;
 	static bool	strict_const_arrays_;
 	static bool	jumps_;
 	static bool	return_structs_;

--- a/src/CLSmith/CLRandomProgramGenerator.cpp
+++ b/src/CLSmith/CLRandomProgramGenerator.cpp
@@ -42,18 +42,8 @@ int main(int argc, char **argv) {
       continue;
     }
 
-    if (!strcmp(argv[idx], "--arrays")) {
-      CGOptions::arrays(true);
-      continue;
-    }
-
     if (!strcmp(argv[idx], "--no-arrays")) {
       CGOptions::arrays(false);
-      continue;
-    }
-
-    if (!strcmp(argv[idx], "--loops")) {
-      CGOptions::loops(true);
       continue;
     }
 

--- a/src/CLSmith/CLRandomProgramGenerator.cpp
+++ b/src/CLSmith/CLRandomProgramGenerator.cpp
@@ -42,6 +42,27 @@ int main(int argc, char **argv) {
       continue;
     }
 
+    if (!strcmp(argv[idx], "--arrays")) {
+      CGOptions::arrays(true);
+      continue;
+    }
+
+    if (!strcmp(argv[idx], "--no-arrays")) {
+      CGOptions::arrays(false);
+      continue;
+    }
+
+    if (!strcmp(argv[idx], "--loops")) {
+      CGOptions::loops(true);
+      continue;
+    }
+
+    if (!strcmp(argv[idx], "--no-loops")) {
+      CGOptions::loops(false);
+      CGOptions::arrays(false);
+      continue;
+    }
+
     if (!strcmp(argv[idx], "--atomic_reductions")) {
       CLSmith::CLOptions::atomic_reductions(true);
       continue;

--- a/src/Probabilities.cpp
+++ b/src/Probabilities.cpp
@@ -776,7 +776,12 @@ Probabilities::set_default_statement_prob()
 	// never generate stand-alone blocks
 	SET_SINGLE_NAME("statement_block_prob", Block, 0);
 	SET_SINGLE_NAME("statement_ifelse_prob", IfElse, 15);
-	SET_SINGLE_NAME("statement_for_prob", For, 30);
+	if (CGOptions::loops()) {
+		SET_SINGLE_NAME("statement_for_prob", For, 30);
+	} else {
+		SET_SINGLE_NAME("statement_for_prob", For, 0);
+		CGOptions::arrays(false);
+	}
 	SET_SINGLE_NAME("statement_return_prob", Return, 35);
 	SET_SINGLE_NAME("statement_continue_prob", Continue, 40);
 	SET_SINGLE_NAME("statement_break_prob", Break, 45);


### PR DESCRIPTION
Hello,

I needed the option to explicitly enable loops and/or array operations in the generated code, so I went ahead and created a patch for it.
