### PR TITLE
Fix build error

### DIFF
--- a/src/Filter.h
+++ b/src/Filter.h
@@ -38,8 +38,6 @@ enum FilterKind {
 	MAX_FILTER_KIND_SIZE,
 };
 
-#define MAX_FILTER_KIND_SIZE ((FilterKind) (fDFS + 1))
-
 // Filter base class
 class Filter
 {

--- a/src/Filter.h
+++ b/src/Filter.h
@@ -35,6 +35,7 @@
 enum FilterKind {
 	fDefault,
 	fDFS,
+	MAX_FILTER_KIND_SIZE,
 };
 
 #define MAX_FILTER_KIND_SIZE ((FilterKind) (fDFS + 1))


### PR DESCRIPTION
Hi,

This fixes the following build error:

```
CLSmith/src/Filter.h:60:14: error: non-type template argument is not a constant expression
   60 |         std::bitset<MAX_FILTER_KIND_SIZE> kinds_;
      |                     ^~~~~~~~~
```~~~~~~~~~~~